### PR TITLE
Catch TypeError for invalid summaries/providers

### DIFF
--- a/stac/collection.py
+++ b/stac/collection.py
@@ -108,8 +108,14 @@ class Collection(Catalog):
         if self._validate:
             Utils.validate(self)
 
-        self._summaries = {k: Stats(v) for k, v in self['summaries'].items()} if 'summaries' in self else {}
-        self._providers = [Provider(provider) for provider in self['providers']] if 'providers' in self else []
+        try:
+            self._summaries = {k: Stats(v) for k, v in self['summaries'].items()} if 'summaries' in self else {}
+        except TypeError:
+            self._summaries = {}
+        try:
+            self._providers = [Provider(provider) for provider in self['providers']] if 'providers' in self else []
+        except TypeError:
+            self._providers = []
 
 
     @property


### PR DESCRIPTION
Catch invalid summaries and providers where they are not Null/Exception instead of a None value. Returns result as if it was a None value anyways.
Resolves the issue where the STAC object attributes for summaries and providers return another type invalid to the code, raising a TypeError.