### PR TITLE
Search filters

### DIFF
--- a/stac/stac.py
+++ b/stac/stac.py
@@ -43,7 +43,7 @@ class STAC:
         self._request_kwargs = request_kwargs
 
     @property
-    def conformance(self): # pragma: no cover
+    def conformance(self):  # pragma: no cover
         """Return the list of conformance classes that the server conforms to."""
         return Utils._get('{}/conformance'.format(self._url), **self._request_kwargs)
 
@@ -61,8 +61,8 @@ class STAC:
             self._catalog = Catalog(response, self._validate)
 
         if not self._collections:
-            self.collections       
-        
+            self.collections
+
         for i in self._catalog.links:
             if i.rel == 'child':
                 if '?' in i.href:  # pragma: no cover
@@ -71,7 +71,6 @@ class STAC:
                 else:
                     self._collections[i.href.split('/')[-1]] = None
         return list(self._collections.keys())
-
 
     @property
     def collections(self):
@@ -87,7 +86,6 @@ class STAC:
 
         return self._collections
 
-
     def collection(self, collection_id) -> Collection:
         """Return the given collection.
 
@@ -98,7 +96,7 @@ class STAC:
         :rtype: dict
         """
         if collection_id in self._collections.keys() and \
-            self._collections[collection_id] is not None:
+                self._collections[collection_id] is not None:
             return self._collections[collection_id]
         try:
             url = '/'.join(self._url.split('/')[:-1]) if self._url.endswith('/stac') else self._url
@@ -109,8 +107,7 @@ class STAC:
             raise KeyError(f'Could not retrieve information for collection: {collection_id}')
         return self._collections[collection_id]
 
-
-    def search(self, filter=None):
+    def search(self, **filter):
         """Retrieve Items matching a filter.
 
         :param filter: (optional) A dictionary with valid STAC query parameters.
@@ -124,7 +121,7 @@ class STAC:
 
         url = f'{self._url}/search{self._access_token}'
 
-        if filter is not None and 'bbox' in filter:
+        if 'bbox' in filter:
             filter['bbox'] = Utils.build_bbox_as_str(filter['bbox'])
 
         data = Utils._get(url, params=filter, **self._request_kwargs)
@@ -140,7 +137,7 @@ class STAC:
         text = 'stac("{}")'.format(self.url)
         return text
 
-    def _repr_html_(self): # pragma: no cover
+    def _repr_html_(self):  # pragma: no cover
         """HTML repr."""
         collections = str()
         for collection in self.catalog:

--- a/stac/utils.py
+++ b/stac/utils.py
@@ -6,7 +6,7 @@
 # under the terms of the MIT License; see LICENSE file for more details.
 #
 """Utility data structures and algorithms."""
-
+import json
 from collections.abc import Iterable
 
 import jinja2
@@ -38,15 +38,15 @@ class Utils:
         """
         response = None
 
-        if params is not None:
-            if 'intersects' in params or 'query' in params:
+        if params:
+            if 'intersects' in params or 'query' in params or 'filter' in params:
                 if 'collections' in params and isinstance(params['collections'], str):
                     params['collections'] = params['collections'].split(',')
                 if 'ids' in params and isinstance(params['ids'], str):
                     params['ids'] = params['ids'].split(',')
                 if 'bbox' in params and isinstance(params['bbox'], str):
                     params['bbox'] = [float(coord) for coord in params['bbox'].split(',')]
-
+                params = json.dumps(params)
                 response = requests.post(url, json=params, **request_kwargs)
             else:
                 if 'collections' in params and type(params['collections']) in (tuple, list):


### PR DESCRIPTION
Changed filters argument from dict to kwarg:
- instead of returning inputting a dict ( e.g. `search(filter={'collections':['collection_id']}`), use kwargs to add it straight to the argument (e.g. `search(collections=['collection_id']`)
- Argument 'filter: dict = None` is the same as `**filter` practically speaking and intuitive for an end user.
- STAC 1.0.0 has field `filter` for faceted search, via post request. Added if `filter` in params dict to run a post search as well.

PyCharm Auto Flake8 changes.