### PR TITLE
Format url

### DIFF
--- a/stac/stac.py
+++ b/stac/stac.py
@@ -35,7 +35,7 @@ class STAC:
         :param access_token: Authentication for the STAC API
         :type access_token: str
         """
-        self._url = url.rstrip('/') if url[-1] == '/' else url
+        self._url = url.rstrip('/')
         self._collections = dict()
         self._catalog = dict()
         self._validate = validate

--- a/stac/stac.py
+++ b/stac/stac.py
@@ -35,7 +35,7 @@ class STAC:
         :param access_token: Authentication for the STAC API
         :type access_token: str
         """
-        self._url = url
+        self._url = url.rstrip('/') if url[-1] == '/' else url
         self._collections = dict()
         self._catalog = dict()
         self._validate = validate


### PR DESCRIPTION
Simple change to ensure there is no trailing '/' at the end of a URL